### PR TITLE
labels are visible now

### DIFF
--- a/app/custom-modeler/custom/CustomElementFactory.js
+++ b/app/custom-modeler/custom/CustomElementFactory.js
@@ -30,7 +30,7 @@ export default function CustomElementFactory(bpmnFactory, moddle) {
     var type = attrs.type;
 
     if (elementType === 'label') {
-      return self.baseCreate(elementType, assign({ type: 'label' }, DEFAULT_LABEL_SIZE, attrs));
+      return self._baseCreate(elementType, assign({ type: 'label' }, DEFAULT_LABEL_SIZE, attrs));
     }
 
     // add type to businessObject if custom


### PR DESCRIPTION
This change resolves the issue I stated in the [forum](https://forum.bpmn.io/t/error-with-updating-bpmn-js-example-custom-shapes/10197). Labels were not visible anymore and changing them lead to crashes. 

Signed-off-by: Jean-Christophe Schmitt <jean-christophe.schmitt@rwth-aachen.de>

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
